### PR TITLE
telemeter.py: correct total usage calculations for products without peak/non-peak

### DIFF
--- a/telemeter/telemeter.py
+++ b/telemeter/telemeter.py
@@ -68,6 +68,10 @@ class TelenetProductUsage(object):
         peak_usage = data["totalusage"].get("peak", 0)
         offpeak_usage = data["totalusage"].get("offpeak", 0)
 
+        total_usage = peak_usage + offpeak_usage
+        if not total_usage:
+            total_usage = data.get("totalusage", {}).get("includedvolume", 0)
+
         included_volume = data.get("includedvolume", 0) + data.get(
             "extendedvolume", {}
         ).get("volume", 0)
@@ -82,7 +86,7 @@ class TelenetProductUsage(object):
             included_volume=included_volume,
             peak_usage=peak_usage,
             offpeak_usage=offpeak_usage,
-            total_usage=peak_usage + offpeak_usage,
+            total_usage=total_usage,
             daily_usage=days,
         )
 


### PR DESCRIPTION
E.G. a "WIGOHOME" subscription currently gives:

Telemeter for 2022-10-23 00:00:00+02:00 to 2022-11-22 00:00:00+01:00
         Usage for WIGOHOMES: 0.00 GiB of 225.00 GiB

Daily usage information for WIGOHOMES
         2022-10-23: 11.06 GiB
         2022-10-24: 2.89 GiB
         2022-10-25: 3.39 GiB
         2022-10-26: 3.41 GiB
         2022-10-27: 3.31 GiB
         2022-10-28: 2.60 GiB
         2022-10-29: 3.96 GiB
         2022-10-30: 6.14 GiB
         2022-10-31: 5.13 GiB
         2022-11-01: 2.82 GiB

This comes from a JSON blob like:

{
    "producttype": "WIGOHOMES",
    "specurl": "https://api.prd.telenet.be/omapi/public/product/20802",
    "squeezed": false,
    "periodstart": "2022-10-23T00:00:00.0+02:00",
    "periodend": "2022-11-22T00:00:00.0+01:00",
    "includedvolume": 209715200,
    "usedpercentage": 22,
    "extendedvolume": {
        "volume": 26214400,
        "cost": 5.0,
        "currency": "EUR"
    },
    "totalusage": {
        "wifree": 0,
        "dailyusages": [
            {
                "date": "2022-10-23T00:00:00.0+02:00",
                "wifree": 0,
                "included": 11599283,
                "extended": 0
            },
            {
                "date": "2022-10-24T00:00:00.0+02:00",
                "wifree": 0,
                "included": 3028985,
                "extended": 0
            },
            {
                "date": "2022-10-25T00:00:00.0+02:00",
                "wifree": 0,
                "included": 3549446,
                "extended": 0
            },
            {
                "date": "2022-10-26T00:00:00.0+02:00",
                "wifree": 0,
                "included": 3574473,
                "extended": 0
            },
            {
                "date": "2022-10-27T00:00:00.0+02:00",
                "wifree": 0,
                "included": 3470037,
                "extended": 0
            },
            {
                "date": "2022-10-28T00:00:00.0+02:00",
                "wifree": 0,
                "included": 2724897,
                "extended": 0
            },
            {
                "date": "2022-10-29T00:00:00.0+02:00",
                "wifree": 0,
                "included": 4149378,
                "extended": 0
            },
            {
                "date": "2022-10-30T00:00:00.0+02:00",
                "wifree": 0,
                "included": 6437292,
                "extended": 0
            },
            {
                "date": "2022-10-31T00:00:00.0+01:00",
                "wifree": 0,
                "included": 5380717,
                "extended": 0
            },
            {
                "date": "2022-11-01T00:00:00.0+01:00",
                "wifree": 0,
                "included": 2960906,
                "extended": 0
            }
        ],
        "includedvolume": 46875414,
        "extendedvolume": 0
    }
}

So fall back to using .totalusage.includedvolume instead of peak+nonpeak, similar to how __str__ behaves differently for products with/without peak.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>